### PR TITLE
Support disabled

### DIFF
--- a/projects/demo/src/app/code.ts
+++ b/projects/demo/src/app/code.ts
@@ -145,6 +145,10 @@ export class FieldTypesDemoComponent implements OnInit {
         Validators.maxLength(10)
       ]
     },
+    {
+      title: 'Good', disabled: true,
+      value: 'Good'
+    },
     { title: 'Hungry?', type: 'switch' },
     { title: 'Programming Questions', type: 'separator' },
     {
@@ -275,7 +279,7 @@ export type QuickFormField = {
   options?: QuickFormFieldOptionDefinition[]
 
   /**
-   * For advanced use case, options can be specified as return value for a function that 
+   * For advanced use case, options can be specified as return value for a function that
    * receives form values as input.
    *
    * If both options and optionsFn is specified, optionsFn will be used instead.
@@ -290,6 +294,11 @@ export type QuickFormField = {
    * Flag to indicate that field input is required. Optional. Defaults to false.
    */
   required?: boolean
+
+  /**
+   * Flag to indicate that field input is disabled. Optional. Defaults to false.
+   */
+  disabled?: boolean
 
   /**
    * For 'select' field type, true to allow multiple selection.

--- a/projects/demo/src/app/field-types-demo/field-types-demo.component.ts
+++ b/projects/demo/src/app/field-types-demo/field-types-demo.component.ts
@@ -17,6 +17,10 @@ export class FieldTypesDemoComponent implements OnInit {
         Validators.maxLength(10)
       ]
     },
+    {
+      title: 'Good', disabled: true,
+      value: 'Good'
+    },
     { title: 'Hungry?', type: 'switch' },
     { title: 'Programming Questions', type: 'separator' },
     {

--- a/projects/ng-quick-form/src/lib/QuickFormField.ts
+++ b/projects/ng-quick-form/src/lib/QuickFormField.ts
@@ -60,6 +60,11 @@ export type QuickFormField = {
   required?: boolean
 
   /**
+   * Flag to indicate that field input is disabled. Optional. Defaults to false.
+   */
+  disabled?: boolean
+
+  /**
    * For 'select' field type, true to allow multiple selection.
    */
   selectMultiple?: boolean

--- a/projects/ng-quick-form/src/lib/makeForm.ts
+++ b/projects/ng-quick-form/src/lib/makeForm.ts
@@ -39,7 +39,7 @@ export const makeForm = (fields: QuickFormField[]) => {
           const options = options2.map(option => {
             const checked = field.value.indexOf(option.value) !== -1
             return fb.group({
-              cb: [ checked ]
+              cb: [ { value: checked, disabled: field.disabled } ]
             })
           })
 
@@ -52,11 +52,11 @@ export const makeForm = (fields: QuickFormField[]) => {
         break
 
       default:
-        form[ fieldId ] = [ field.value || '', [
-          ...(field.validators || [])
-        ], [
-          ...(field.asyncValidators || [])
-        ] ]
+        form[ fieldId ] = [
+          { value: field.value || '', disabled: field.disabled },
+          [ ...(field.validators || []) ],
+          [ ...(field.asyncValidators || []) ]
+        ]
     }
   })
 


### PR DESCRIPTION
Add disabled support for quick form field

<img width="663" alt="Screenshot 2019-06-05 at 1 46 16 PM" src="https://user-images.githubusercontent.com/6244226/58932963-5dccea80-8798-11e9-8d38-3e6ec0ccb7bb.png">

<img width="696" alt="Screenshot 2019-06-05 at 1 46 27 PM" src="https://user-images.githubusercontent.com/6244226/58932972-62919e80-8798-11e9-8685-ab5013626757.png">

Documentation (`code.ts`) updated.

Example (`field-types-demo.component.ts`) updated  with example below:
```
    {
      title: 'Good', disabled: true,
      value: 'Good'
    },
```