### PR TITLE
Fix missing label for appearance standard, fill and outline

### DIFF
--- a/projects/ng-quick-form/src/lib/mat/QuickFormField.component.html
+++ b/projects/ng-quick-form/src/lib/mat/QuickFormField.component.html
@@ -1,6 +1,7 @@
 <ng-container [formGroup]="form" [ngSwitch]="field.type">
     <!--text field-->
     <mat-form-field *ngSwitchCase="'text'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <input matInput [formControlName]="fieldId" [placeholder]="field.title"
                [required]="field.required">
         <mat-error *ngIf="!form.controls[fieldId].valid">
@@ -10,6 +11,7 @@
 
     <!--autocomplete-->
     <mat-form-field *ngSwitchCase="'autocomplete'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <input matInput [formControlName]="fieldId" [placeholder]="field.title"
                [required]="field.required" [matAutocomplete]="auto">
         <mat-autocomplete autoActiveFirstOption #auto="matAutocomplete">
@@ -24,6 +26,7 @@
 
     <!--password-->
     <mat-form-field *ngSwitchCase="'password'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <input matInput type="password" [formControlName]="fieldId" [placeholder]="field.title"
                [required]="field.required">
         <mat-error *ngIf="!form.controls[fieldId].valid">
@@ -33,6 +36,7 @@
 
     <!--textarea-->
     <mat-form-field *ngSwitchCase="'textarea'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <textarea matInput cdkTextareaAutosize [formControlName]="fieldId"
                   [placeholder]="field.title" [required]="field.required">
         </textarea>
@@ -43,6 +47,7 @@
 
     <!--chip-->
     <mat-form-field *ngSwitchCase="'chips'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <mat-chip-list #chipList>
             <mat-chip
                     *ngFor="let chipValue of chipValues"
@@ -84,6 +89,7 @@
 
     <!--select-->
     <mat-form-field *ngSwitchCase="'select'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <mat-select [formControlName]="fieldId" [placeholder]="field.title"
                     [multiple]="field.selectMultiple"
                     [required]="field.required">
@@ -98,11 +104,13 @@
 
     <!--switch field-->
     <div *ngSwitchCase="'switch'" typography-body-1 width-full>
+        <mat-label>{{field.title}}</mat-label>
         <mat-slide-toggle [formControlName]="fieldId">{{field.title}}</mat-slide-toggle>
     </div>
 
     <!--radio field-->
     <div *ngSwitchCase="'radio'" width-full>
+        <mat-label>{{field.title}}</mat-label>
         <mat-radio-group [formControlName]="fieldId" [required]="field.required">
             <label typography-caption>{{field.title}}</label>
             <div flex-cell gutter padding-bottom>


### PR DESCRIPTION
Root cause:
Appearance `standard`, `fill` and `outline` require `mat-label` while `legacy` did not require

Before fix:
<img width="703" alt="Screenshot 2019-06-06 at 12 10 12 AM" src="https://user-images.githubusercontent.com/6244226/58972433-24c06480-87f0-11e9-85b5-2f41e73606fb.png">

After fix:
<img width="702" alt="Screenshot 2019-06-06 at 12 09 20 AM" src="https://user-images.githubusercontent.com/6244226/58972439-28ec8200-87f0-11e9-8dd7-865764040fcb.png">
