### PR TITLE
Fix duplicate label for radio

### DIFF
--- a/projects/ng-quick-form/src/lib/mat/QuickFormField.component.html
+++ b/projects/ng-quick-form/src/lib/mat/QuickFormField.component.html
@@ -137,13 +137,11 @@
 
     <!--radio field-->
     <div *ngSwitchCase="'radio'" width-full>
-        <mat-label>{{field.title}}</mat-label>
+        <mat-label>{{field.title}}
+            <mat-icon *ngIf="field.suffixIcon" matSuffix inline="true"
+                      [matTooltip]="field.suffixIconTooltip">
+                {{field.suffixIcon}}</mat-icon></mat-label>
         <mat-radio-group [formControlName]="fieldId" [required]="field.required">
-            <label typography-caption>{{field.title}}
-                <mat-icon *ngIf="field.suffixIcon" matSuffix inline="true"
-                          [matTooltip]="field.suffixIconTooltip">
-                    {{field.suffixIcon}}</mat-icon>
-            </label>
             <div flex-cell gutter padding-bottom>
                 <mat-radio-button *ngFor="let option of finalOptions" [value]="option.value"
                                   [attr.cell-1]="cellPerOption == 1 ? true : null"


### PR DESCRIPTION
Fix duplicate label for radio

Before fix:
<img width="480" alt="Screenshot 2019-06-23 at 12 04 22 PM" src="https://user-images.githubusercontent.com/6244226/59971460-107db500-95af-11e9-8840-ef7bcce82cf9.png">

After fix:
<img width="485" alt="Screenshot 2019-06-23 at 12 04 56 PM" src="https://user-images.githubusercontent.com/6244226/59971464-22f7ee80-95af-11e9-8fb8-9fef92648f12.png">
